### PR TITLE
Add compatibility to Spring Boot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.hrytsenko</groupId>
     <artifactId>json-data-spring-boot</artifactId>
-    <version>0.2.1</version>
+    <version>0.3.0</version>
 
     <url>https://github.com/hrytsenko/json-data-spring-boot</url>
     <inceptionYear>2020</inceptionYear>
@@ -46,13 +46,13 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <spring.version>2.4.13</spring.version>
+        <spring.version>3.0.2</spring.version>
 
         <json-data.version>0.2.1</json-data.version>
 
         <lombock.version>1.18.24</lombock.version>
-        <junit.version>5.8.2</junit.version>
-        <mockito.version>4.6.1</mockito.version>
+        <junit.version>5.9.2</junit.version>
+        <mockito.version>4.8.1</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -148,12 +148,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/github/hrytsenko/jsondata/springboot/JsonDataAutoConfiguration.java
+++ b/src/main/java/com/github/hrytsenko/jsondata/springboot/JsonDataAutoConfiguration.java
@@ -20,15 +20,15 @@ import com.github.hrytsenko.jsondata.JsonValidator;
 import com.github.hrytsenko.jsondata.springboot.error.CorrelationSource;
 import com.github.hrytsenko.jsondata.springboot.web.ValidatorSource;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
-@ComponentScan(basePackageClasses = AutoConfiguration.class)
 @Slf4j
-class AutoConfiguration {
+@AutoConfiguration
+@ComponentScan(basePackageClasses = JsonDataAutoConfiguration.class)
+class JsonDataAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.github.hrytsenko.jsondata.springboot.AutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.github.hrytsenko.jsondata.springboot.JsonDataAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.json.AutoConfigureJson.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.json.AutoConfigureJson.imports
@@ -1,0 +1,1 @@
+com.github.hrytsenko.jsondata.springboot.JsonDataAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.json.AutoConfigureJsonTesters.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.json.AutoConfigureJsonTesters.imports
@@ -1,0 +1,1 @@
+com.github.hrytsenko.jsondata.springboot.JsonDataAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc.imports
@@ -1,0 +1,1 @@
+com.github.hrytsenko.jsondata.springboot.JsonDataAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc.imports
@@ -1,0 +1,1 @@
+com.github.hrytsenko.jsondata.springboot.JsonDataAutoConfiguration

--- a/src/test/java/com/github/hrytsenko/jsondata/springboot/JsonDataAutoConfigurationTest.java
+++ b/src/test/java/com/github/hrytsenko/jsondata/springboot/JsonDataAutoConfigurationTest.java
@@ -20,11 +20,11 @@ import com.github.hrytsenko.jsondata.springboot.web.ValidatorSource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class AutoConfigurationTest {
+class JsonDataAutoConfigurationTest {
 
     @Test
     void correlationSource_undefined() {
-        CorrelationSource correlationSource = new AutoConfiguration().undefinedCorrelationSource();
+        CorrelationSource correlationSource = new JsonDataAutoConfiguration().undefinedCorrelationSource();
 
         String actualCorrelation = correlationSource.getCorrelation();
 
@@ -33,7 +33,7 @@ class AutoConfigurationTest {
 
     @Test
     void validatorSource_default() {
-        ValidatorSource validatorSource = new AutoConfiguration().defaultValidatorSource();
+        ValidatorSource validatorSource = new JsonDataAutoConfiguration().defaultValidatorSource();
 
         Assertions.assertDoesNotThrow(
                 () -> validatorSource.getValidator("empty-schema.json"));


### PR DESCRIPTION
Hi, I like this library (and the underlying json-data) because it allows to produce clean and declarative code and I'd like to use it in my latest project but I can't because it's not compatible with Spring Boot 3, which [changed how it registers auto-configurations](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#auto-configuration-registration).

If it's ok with you, I'd like to contribute to the library with this PR instead of just forking it.
The changes I made should be retro-compatible, I've tried the new version with a Spring Boot 2.3 project and it registers the auto-configuration.

Please let my know if you need me to do or change something.